### PR TITLE
Missing features for compiling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bech32 = "0.9.1"
 bitcoin_hashes = { version = "0.12.0", default-features = false }
-bitcoin = { version = "0.29.2", default-features = false, features = ["serde"] }
+bitcoin = { version = "=0.29.2", default-features = false, features = ["serde", "std", "rand"] }
 ureq = { version = "2.5.0", features = ["json"], optional = true }
 reqwest = { version = "0.11", optional = true, default-features = false, features = ["json"] }
 email_address = "0.2.4"


### PR DESCRIPTION
Couldn't compile `lnurl-rs`

* Pinned `0.29.2` 
* Added `rand` feature for `pay:146`
* Added `std` because `bitcoin@0.29.2` requires at least `std` or `no-std`