### PR TITLE
Add 'no-std' feature on bitcoin dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ anyhow = "1.0.70"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bech32 = "0.11"
-bitcoin = { version = "0.30.2", default-features = false, features = ["serde", "rand"] }
+bitcoin = { version = "0.30.2", default-features = false, features = ["no-std", "serde", "rand"] }
 ureq = { version = "2.5.0", features = ["json"], optional = true }
 reqwest = { version = "0.12.3", optional = true, default-features = false, features = ["json"] }
 email_address = "=0.2.5"


### PR DESCRIPTION
The bitcoin crate gives a compile error if neither the std nor no-std feature is selected.