### PR TITLE
Rename async-https feature to async-https-native and deprecate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,5 +41,6 @@ nostr = { version = "0.25.0", default-features = false, features = ["std"] }
 default = ["blocking", "async", "async-https"]
 blocking = ["ureq", "ureq/socks"]
 async = ["reqwest", "reqwest/socks"]
-async-https = ["reqwest/default-tls", "async"]
+async-https = ["async-https-native"] # deprecated
+async-https-native = ["reqwest/default-tls", "async"]
 async-https-rustls = ["reqwest/rustls-tls", "async"]


### PR DESCRIPTION
Follow-up on https://github.com/benthecarman/lnurl-rs/pull/28.

Not sure if you'd want this, so separate MR.