### PR TITLE
Verify callback invoice amount in get_invoice

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ let res = async_client.make_request(url).await.unwrap();
 
 if let LnUrlPayResponse(pay) = res {
     let msats = 1_000_000;
+    // `get_invoice` verifies that the returned invoice's amount matches `msats`
+    // (per LUD-06), returning an error otherwise.
     let pay_result = async_client.get_invoice(&pay, msats, None, None).await.unwrap();
 
     let invoice = Bolt11Invoice::from_str(&pay_result.invoice()).unwrap();

--- a/src/async.rs
+++ b/src/async.rs
@@ -97,7 +97,12 @@ impl AsyncClient {
 
         let resp = self.client.get(&url).send().await?;
 
-        Ok(resp.error_for_status()?.json().await?)
+        let invoice: LnURLPayInvoice = resp.error_for_status()?.json().await?;
+
+        // verify the returned invoice's amount matches the requested amount (LUD-06)
+        invoice.verify_amount(msats)?;
+
+        Ok(invoice)
     }
 
     pub async fn verify(&self, url: &str) -> Result<VerifyResponse, Error> {

--- a/src/blocking.rs
+++ b/src/blocking.rs
@@ -96,7 +96,11 @@ impl BlockingClient {
                 let result = serde_json::from_value::<LnURLPayInvoice>(json.clone());
 
                 match result {
-                    Ok(invoice) => Ok(invoice),
+                    Ok(invoice) => {
+                        // verify the returned invoice's amount matches the requested amount (LUD-06)
+                        invoice.verify_amount(msats)?;
+                        Ok(invoice)
+                    }
                     Err(_) => {
                         let response = serde_json::from_value::<Response<()>>(json)?;
                         match response {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,6 +79,16 @@ pub enum Error {
     InvalidComment,
     /// Invalid amount on request
     InvalidAmount,
+    /// The BOLT11 invoice returned by the callback could not be parsed
+    InvalidInvoice(String),
+    /// The BOLT11 invoice amount does not match the requested amount
+    InvoiceAmountMismatch {
+        /// The amount that was requested, in millisatoshis
+        requested_msats: u64,
+        /// The amount encoded in the returned invoice, in millisatoshis,
+        /// or `None` if the invoice did not specify an amount
+        invoice_msats: Option<u64>,
+    },
     /// Error during ureq HTTP request
     #[cfg(feature = "blocking")]
     Ureq(ureq::Error),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -238,7 +238,7 @@ mod tests {
     #[cfg(all(feature = "blocking", any(feature = "async", feature = "async-https")))]
     #[tokio::test]
     async fn test_get_invoice_with_comment() {
-        let url = "https://getalby.com/.well-known/lnurlp/nvk";
+        let url = "https://primal.net/.well-known/lnurlp/odell";
         let (blocking_client, async_client) = setup_clients().await;
 
         let res = blocking_client.make_request(url).unwrap();

--- a/src/pay.rs
+++ b/src/pay.rs
@@ -3,18 +3,19 @@ use aes::cipher::{BlockDecryptMut, BlockEncryptMut, KeyIvInit};
 use aes::Aes256;
 use base64::engine::general_purpose::STANDARD as BASE64_STANDARD;
 use base64::Engine;
+use bech32::primitives::decode::UncheckedHrpstring;
 use bitcoin::hashes::sha256::Hash as Sha256;
 use bitcoin::hashes::Hash;
 use bitcoin::key::XOnlyPublicKey;
 use cbc::{Decryptor, Encryptor};
 use serde::{Deserialize, Serialize};
-use std::convert::TryInto;
+use std::convert::{TryFrom, TryInto};
 use url::Url;
 
 type Aes256CbcEnc = Encryptor<Aes256>;
 type Aes256CbcDec = Decryptor<Aes256>;
 
-use crate::Tag;
+use crate::{Error, Tag};
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct PayResponse {
@@ -102,6 +103,98 @@ impl LnURLPayInvoice {
     pub fn success_action(&self) -> Option<SuccessAction> {
         self.success_action.clone().map(SuccessAction::from_params)
     }
+
+    /// Verify that the BOLT11 invoice's amount equals the requested amount in
+    /// millisatoshis, as required by LUD-06 before the invoice is paid.
+    ///
+    /// Returns [`Error::InvalidInvoice`] if `pr` cannot be parsed as a BOLT11
+    /// invoice, and [`Error::InvoiceAmountMismatch`] if the invoice amount is
+    /// absent or differs from `msats`.
+    pub fn verify_amount(&self, msats: u64) -> Result<(), Error> {
+        let invoice_msats = parse_bolt11_amount_msats(&self.pr)?;
+        if invoice_msats != Some(msats) {
+            return Err(Error::InvoiceAmountMismatch {
+                requested_msats: msats,
+                invoice_msats,
+            });
+        }
+
+        Ok(())
+    }
+}
+
+/// Parse the amount (in millisatoshis) encoded in a BOLT11 invoice without
+/// pulling in a full invoice-parsing dependency.
+///
+/// The amount lives entirely in the human-readable part (HRP) of the invoice,
+/// so we only parse and validate the bech32 structure (via the `bech32` crate)
+/// and read the amount out of the HRP. The HRP is `ln` + a currency prefix
+/// (letters only) + an optional amount, where the amount is one or more digits
+/// followed by an optional multiplier letter (`m`/`u`/`n`/`p`).
+///
+/// Returns `Ok(None)` for an amountless invoice, `Ok(Some(msats))` when an
+/// amount is present, and [`Error::InvalidInvoice`] if the HRP is malformed.
+// `u128::is_multiple_of` is too new for this crate's MSRV.
+#[allow(clippy::manual_is_multiple_of)]
+fn parse_bolt11_amount_msats(invoice: &str) -> Result<Option<u64>, Error> {
+    let invalid = |msg: &str| Error::InvalidInvoice(msg.to_string());
+
+    // Parse the bech32 structure to split off and validate the human-readable
+    // part. We deliberately do not verify the checksum: BOLT11 invoices are not
+    // length-bounded, the amount lives entirely in the HRP, and the invoice
+    // signature is the (possibly malicious) service's own, so a checksum check
+    // would add no protection against a mismatched amount.
+    let parsed =
+        UncheckedHrpstring::new(invoice).map_err(|e| Error::InvalidInvoice(e.to_string()))?;
+    // The HRP is all lower- or all upper-case (mixed case is rejected by the
+    // parser above); normalize so the `ln` prefix and multiplier letters match.
+    let hrp = parsed.hrp().as_str().to_ascii_lowercase();
+
+    if !hrp.starts_with("ln") {
+        return Err(invalid("not a lightning invoice"));
+    }
+
+    // The currency prefix contains no digits, so the amount section (if any)
+    // starts at the first digit in the HRP.
+    let amount = match hrp.find(|c: char| c.is_ascii_digit()) {
+        None => return Ok(None), // amountless invoice
+        Some(idx) => &hrp[idx..],
+    };
+
+    // Split off an optional trailing multiplier letter.
+    let (digits, multiplier) = match amount.chars().last() {
+        Some(c) if c.is_ascii_digit() => (amount, None),
+        Some(c) => (&amount[..amount.len() - 1], Some(c)),
+        None => unreachable!("amount is non-empty"),
+    };
+
+    let value: u128 = digits
+        .parse()
+        .map_err(|_| invalid("invalid amount digits"))?;
+
+    // Convert to millisatoshis. 1 BTC = 100_000_000_000 msat, and the BOLT11
+    // multipliers scale the value by 10^-3 (m), 10^-6 (u), 10^-9 (n), 10^-12 (p)
+    // bitcoin respectively.
+    let msats: u128 = match multiplier {
+        None => value.checked_mul(100_000_000_000),
+        Some('m') => value.checked_mul(100_000_000),
+        Some('u') => value.checked_mul(100_000),
+        Some('n') => value.checked_mul(100),
+        Some('p') => {
+            // A pico-bitcoin amount must be a multiple of 10, as 1 msat is the
+            // smallest representable unit (10 pico-bitcoin).
+            if value % 10 != 0 {
+                return Err(invalid("sub-millisatoshi amount"));
+            }
+            Some(value / 10)
+        }
+        Some(_) => return Err(invalid("invalid amount multiplier")),
+    }
+    .ok_or_else(|| invalid("amount overflow"))?;
+
+    let msats = u64::try_from(msats).map_err(|_| invalid("amount overflow"))?;
+
+    Ok(Some(msats))
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
@@ -278,6 +371,129 @@ mod test {
         assert!(parsed.settled);
         assert!(parsed.preimage.is_some());
         assert!(parsed.pr.starts_with("lnbc10"));
+    }
+
+    // Real BOLT11 invoices from the BOLT #11 test vectors, with known amounts.
+
+    // Amountless donation invoice.
+    const AMOUNTLESS: &str = "lnbc1pvjluezpp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqdpl2pkx2ctnv5sxxmmwwd5kgetjypeh2ursdae8g6na6hlh";
+    // 2500u = 250_000_000 msat (250_000 sat).
+    const INV_250_000_000_MSAT: &str = "lnbc2500u1pvjluezpp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqdpquwpc4curk03c9wlrswe78q4eyqc7d8d0xqzpuyk0sg5g70me25alkluzd2x62aysf2pyy8edtjeevuv4p2d5p76r4zkmneet7uvyakky2zr4cusd45tftc9c5fh0nnqpnl2jfll544esqchsrnt";
+    // 20m = 2_000_000_000 msat (0.02 BTC).
+    const INV_2_000_000_000_MSAT: &str = "lnbc20m1pvjluezpp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqhp58yjmdan79s6qqdhdzgynm4zwqd5d7xmw5fk98klysy043l2ahrqs9qrsgq7ea976txfraylvgzuxs8kgcw23ezlrszfnh8r6qtfpr6cxga50aj6txm9rxrydzd06dfeawfk6swupvz4erwnyutnjq7x39ymw6j38gp49qdkj";
+    // 10m = 1_000_000_000 msat (0.01 BTC).
+    const INV_1_000_000_000_MSAT: &str = "lnbc10m1pvjluezpp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqdp9wpshjmt9de6zqmt9w3skgct5vysxjmnnd9jx2mq8q8a04uqsp5zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zygs9q2gqqqqqqsgq7hf8he7ecf7n4ffphs6awl9t6676rrclv9ckg3d3ncn7fct63p6s365duk5wrk202cfy3aj5xnnp5gs3vrdvruverwwq7yzhkf5a3xqpd05wjc";
+    // 9678785340p = 967_878_534 msat: a whole-millisatoshi but non-whole-sat amount.
+    const INV_967_878_534_MSAT: &str = "lnbc9678785340p1pwmna7lpp5gc3xfm08u9qy06djf8dfflhugl6p7lgza6dsjxq454gxhj9t7a0sd8dgfkx7cmtwd68yetpd5s9xar0wfjn5gpc8qhrsdfq24f5ggrxdaezqsnvda3kkum5wfjkzmfqf3jkgem9wgsyuctwdus9xgrcyqcjcgpzgfskx6eqf9hzqnteypzxz7fzypfhg6trddjhygrcyqezcgpzfysywmm5ypxxjemgw3hxjmn8yptk7untd9hxwg3q2d6xjcmtv4ezq7pqxgsxzmnyyqcjqmt0wfjjq6t5v4khxsp5zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zygsxqyjw5qcqp2rzjq0gxwkzc8w6323m55m4jyxcjwmy7stt9hwkwe2qxmy8zpsgg7jcuwz87fcqqeuqqqyqqqqlgqqqqn3qq9q9qrsgqrvgkpnmps664wgkp43l22qsgdw4ve24aca4nymnxddlnp8vh9v2sdxlu5ywdxefsfvm0fq3sesf08uf6q9a2ke0hc9j6z6wlxg5z5kqpu2v9wz";
+    // testnet 20m = 2_000_000_000 msat.
+    const TESTNET_INV_2_000_000_000_MSAT: &str = "lntb20m1pvjluezsp5zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zygshp58yjmdan79s6qqdhdzgynm4zwqd5d7xmw5fk98klysy043l2ahrqspp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqfpp3x9et2e20v6pu37c5d9vax37wxq72un989qrsgqdj545axuxtnfemtpwkc45hx9d2ft7x04mt8q7y6t0k2dge9e7h8kpy9p34ytyslj3yu569aalz2xdk8xkd7ltxqld94u8h2esmsmacgpghe9k8";
+    // 2500000001p has sub-millisatoshi precision and must be rejected.
+    const SUB_MSAT: &str = "lnbc2500000001p1pvjluezpp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqdq5xysxxatsyp3k7enxv4jsxqzpusp5zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zygs9qrsgq0lzc236j96a95uv0m3umg28gclm5lqxtqqwk32uuk4k6673k6n5kfvx3d2h8s295fad45fdhmusm8sjudfhlf6dcsxmfvkeywmjdkxcp99202x";
+
+    #[test]
+    fn test_parse_bolt11_amount() {
+        let parse = |s: &str| parse_bolt11_amount_msats(s).unwrap();
+
+        assert_eq!(parse(AMOUNTLESS), None);
+        assert_eq!(parse(INV_250_000_000_MSAT), Some(250_000_000));
+        assert_eq!(parse(INV_2_000_000_000_MSAT), Some(2_000_000_000));
+        assert_eq!(parse(INV_1_000_000_000_MSAT), Some(1_000_000_000));
+        assert_eq!(parse(INV_967_878_534_MSAT), Some(967_878_534));
+        assert_eq!(parse(TESTNET_INV_2_000_000_000_MSAT), Some(2_000_000_000));
+    }
+
+    #[test]
+    fn test_parse_bolt11_amount_invalid() {
+        // sub-millisatoshi precision (pico amount not a multiple of 10)
+        assert!(matches!(
+            parse_bolt11_amount_msats(SUB_MSAT),
+            Err(Error::InvalidInvoice(_))
+        ));
+        // not a lightning invoice
+        assert!(matches!(
+            parse_bolt11_amount_msats("not a real invoice"),
+            Err(Error::InvalidInvoice(_))
+        ));
+        // amount that overflows u64 millisatoshis. No real invoice can carry
+        // such a value, so this exercises the HRP parser directly.
+        assert!(matches!(
+            parse_bolt11_amount_msats("lnbc99999999999991q"),
+            Err(Error::InvalidInvoice(_))
+        ));
+    }
+
+    #[test]
+    fn test_verify_amount_matches() {
+        let inv = LnURLPayInvoice::new(INV_250_000_000_MSAT.to_string());
+        assert!(inv.verify_amount(250_000_000).is_ok());
+    }
+
+    #[test]
+    fn test_verify_amount_larger_invoice() {
+        // invoice is for 2_000_000_000 msat, but only 250_000_000 was requested
+        let inv = LnURLPayInvoice::new(INV_2_000_000_000_MSAT.to_string());
+        match inv.verify_amount(250_000_000) {
+            Err(Error::InvoiceAmountMismatch {
+                requested_msats,
+                invoice_msats,
+            }) => {
+                assert_eq!(requested_msats, 250_000_000);
+                assert_eq!(invoice_msats, Some(2_000_000_000));
+            }
+            other => panic!("expected mismatch, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_verify_amount_smaller_invoice() {
+        // invoice is for 250_000_000 msat, but 2_000_000_000 was requested
+        let inv = LnURLPayInvoice::new(INV_250_000_000_MSAT.to_string());
+        match inv.verify_amount(2_000_000_000) {
+            Err(Error::InvoiceAmountMismatch {
+                requested_msats,
+                invoice_msats,
+            }) => {
+                assert_eq!(requested_msats, 2_000_000_000);
+                assert_eq!(invoice_msats, Some(250_000_000));
+            }
+            other => panic!("expected mismatch, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_verify_amount_amountless_invoice() {
+        let inv = LnURLPayInvoice::new(AMOUNTLESS.to_string());
+        match inv.verify_amount(250_000_000) {
+            Err(Error::InvoiceAmountMismatch {
+                requested_msats,
+                invoice_msats,
+            }) => {
+                assert_eq!(requested_msats, 250_000_000);
+                assert_eq!(invoice_msats, None);
+            }
+            other => panic!("expected mismatch, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_verify_amount_non_whole_sat() {
+        // 967_878_534 msat is not a whole number of sats
+        let inv = LnURLPayInvoice::new(INV_967_878_534_MSAT.to_string());
+        assert!(inv.verify_amount(967_878_534).is_ok());
+        // rounding the requested amount to whole sats must be rejected
+        assert!(matches!(
+            inv.verify_amount(967_878_000),
+            Err(Error::InvoiceAmountMismatch { .. })
+        ));
+    }
+
+    #[test]
+    fn test_verify_amount_invalid_invoice() {
+        let inv = LnURLPayInvoice::new("not a real invoice".to_string());
+        assert!(matches!(
+            inv.verify_amount(250_000_000),
+            Err(Error::InvalidInvoice(_))
+        ));
     }
 
     #[test]


### PR DESCRIPTION
LUD-06 requires the wallet to verify that the BOLT11 invoice returned by the LNURL-pay callback encodes the same amount the user requested before paying it. Both get_invoice helpers validated msats against min/max_sendable but returned the callback invoice without checking its embedded amount.

A malicious service could advertise a small amount, accept the callback for that amount, then return an invoice for a larger amount. A wallet treating get_invoice as the safe invoice-fetching helper would pay more than the user authorized, since LNURL-pay has no second confirmation after the invoice is fetched.

Reject the returned invoice when its amount is absent or differs from the requested msats, via a new verify_amount helper shared by the async and blocking clients. The amount lives in the invoice's human-readable part, so it is parsed directly rather than taking a dependency on a full BOLT11 parser. Add InvalidInvoice and InvoiceAmountMismatch error variants.